### PR TITLE
Change topic and queue name

### DIFF
--- a/cadf/map.jinja
+++ b/cadf/map.jinja
@@ -24,9 +24,9 @@ dispatcher:
     port: 5672
     user: admin
     password: adminpassword
-    queue: notifications.info
+    queue: cadf.info
     vhost: /openstack
-    topic: notifications
+    topic: cadf
   http_server:
     url: 127.0.0.1:33333
   pkgs:


### PR DESCRIPTION
Due to current settings services push all notifications to separated topic and queue